### PR TITLE
Prevent silent errors from allowing validation

### DIFF
--- a/app/models/BaseModel.php
+++ b/app/models/BaseModel.php
@@ -1,5 +1,7 @@
 <?php
 
+use Acme\Validation\ValidationException;
+
 class BaseModel extends Eloquent {
 
     /**
@@ -24,6 +26,10 @@ class BaseModel extends Eloquent {
         if (class_exists($path))
         {
             App::make($path)->validateForUpdate($attributes);
+        }
+        else
+        {
+            throw new ValidationException('Validator class not found');
         }
 
         parent::update($attributes);


### PR DESCRIPTION
If the class_exists check fails, this will allow the model to update itself without validation.

Otherwise what is currently occurring is the validation fails (because it cannot find a {$class}Validator, and then it is still allowing the update to occur on the model, with no error or indication anything is wrong!
